### PR TITLE
.travis.yml: enable instead of with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 env:
   - CONFIGURE_WITH=""
   - CONFIGURE_WITH="--with-perl"
-  - CONFIGURE_WITH="--with-contrib"
+  - CONFIGURE_WITH="--enable-contrib"
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -q -y libperl-dev


### PR DESCRIPTION
I am not fully sure about this, but .travis.yml read `--with-contrib`
and ./configure still said "Contrib modules: no". It changes to "yes"
when --enable-contrib is used.