### PR TITLE
Preserve ACL setter name through accountname changes.

### DIFF
--- a/include/abirev.h
+++ b/include/abirev.h
@@ -16,7 +16,7 @@
  * digits and set the rest to 0 (e.g. 330000). Otherwise, increment
  * the lower digits.
  */
-#define CURRENT_ABI_REVISION 710003
+#define CURRENT_ABI_REVISION 800000
 
 #endif
 

--- a/include/account.h
+++ b/include/account.h
@@ -210,7 +210,7 @@ struct chanacs_
 	mowgli_node_t    cnode;
 	mowgli_node_t    unode;
 
-	stringref setter;
+	myentity_t *setter;
 };
 
 /* the new atheme-style channel flags */

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -1380,7 +1380,7 @@ static void chanacs_delete(chanacs_t *ca)
 	}
 
 	if (ca->setter != NULL)
-		strshare_unref(ca->setter);
+		object_unref(ca->setter);
 
 	metadata_delete_all(ca);
 
@@ -1432,7 +1432,7 @@ chanacs_t *chanacs_add(mychan_t *mychan, myentity_t *mt, unsigned int level, tim
 	ca->host = NULL;
 	ca->level = level & ca_all;
 	ca->tmodified = ts;
-	ca->setter = setter != NULL ? strshare_ref(setter->name) : NULL;
+	ca->setter = setter != NULL ? setter : NULL;
 
 	mowgli_node_add(ca, &ca->cnode, &mychan->chanacs);
 	mowgli_node_add(ca, &ca->unode, &mt->chanacs);
@@ -1482,7 +1482,7 @@ chanacs_t *chanacs_add_host(mychan_t *mychan, const char *host, unsigned int lev
 	ca->host = sstrdup(host);
 	ca->level = level & ca_all;
 	ca->tmodified = ts;
-	ca->setter = setter != NULL ? strshare_ref(setter->name) : NULL;
+	ca->setter = setter != NULL ? setter : NULL;
 
 	mowgli_node_add(ca, &ca->cnode, &mychan->chanacs);
 
@@ -1851,7 +1851,7 @@ bool chanacs_modify(chanacs_t *ca, unsigned int *addflags, unsigned int *removef
 		return false;
 	ca->level = (ca->level | *addflags) & ~*removeflags;
 	ca->tmodified = CURRTIME;
-	ca->setter = entity(setter)->name;
+	ca->setter = entity(setter);
 
 	return true;
 }
@@ -1915,7 +1915,7 @@ bool chanacs_change(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsi
 				return false;
 			ca->level = (ca->level | *addflags) & ~*removeflags;
 			ca->tmodified = CURRTIME;
-			ca->setter = setter->name;
+			ca->setter = setter;
 			if (ca->level == 0)
 				object_unref(ca);
 		}
@@ -1952,7 +1952,7 @@ bool chanacs_change(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsi
 				return false;
 			ca->level = (ca->level | *addflags) & ~*removeflags;
 			ca->tmodified = CURRTIME;
-			ca->setter = setter->name;
+			ca->setter = setter;
 			if (ca->level == 0)
 				object_unref(ca);
 		}

--- a/modules/backend/corestorage.c
+++ b/modules/backend/corestorage.c
@@ -201,7 +201,7 @@ corestorage_db_save(database_handle_t *db)
 			db_write_word(db, ca->entity ? ca->entity->name : ca->host);
 			db_write_word(db, bitmask_to_flags(ca->level));
 			db_write_time(db, ca->tmodified);
-			db_write_word(db, ca->setter ? ca->setter : "*");
+			db_write_word(db, ca->setter ? ca->setter->name : "*");
 			db_commit_row(db);
 
 			if (object(ca)->metadata)

--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -134,10 +134,10 @@ static void do_list(sourceinfo_t *si, mychan_t *mc, unsigned int flags)
 
 		if (template != NULL)
 			command_success_nodata(si, _("%-5d %-22s %-20s (%s) (%s) [modified %s ago, on %s by %s]"),
-				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), template, mc->name, mod_ago, mod_date, ca->setter ? ca->setter : "?");
+				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), template, mc->name, mod_ago, mod_date, ca->setter ? ca->setter->name : "?");
 		else
 			command_success_nodata(si, _("%-5d %-22s %-20s (%s) [modified %s ago, on %s by %s]"),
-				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), mc->name, mod_ago, mod_date, ca->setter ? ca->setter : "?");
+				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), mc->name, mod_ago, mod_date, ca->setter ? ca->setter->name : "?");
 		i++;
 	}
 


### PR DESCRIPTION
The pull request that got merged into master yesterday worked but they didn't change the accountname. Thanks to mt on #shalture for pointing this out to me, it's been fixed.