### PR TITLE
Fix minor errors in Spanish email files

### DIFF
--- a/email/es/memo
+++ b/email/es/memo
@@ -1,7 +1,7 @@
 From: &from&
 To: &to&
 Reply-To: &replyto&
-Subject: Nuevo meemo en &netname&
+Subject: Nuevo memo en &netname&
 Date: &date&
 
 &accountname&,
@@ -13,5 +13,5 @@ Has recibido un nuevo memo de &entityname&:
 Para desactivar estos mensajes, escriba /msg &nicksvs& SET EMAILMEMOS OFF
 en el IRC.
 --
-Si usted no ha solicitado este mensaje, por favor contacte a &replyto&
-con una copia del mismo.
+Si no has solicitado este mensaje, por favor contacte a &replyto&
+con una copia completa del mismo.

--- a/email/es/register
+++ b/email/es/register
@@ -6,14 +6,14 @@ Date: &date&
 
 &accountname&,
 
-Para completar el registro de su cuenta debes introducir el siguiente
+Para completar el registro de tu cuenta debes introducir el siguiente
 comando en el IRC:
 
    /msg &nicksvs& VERIFY REGISTER &accountname& &param&
 
-¡Gracias por registrar su cuenta en la red IRC &netname&!
+¡Gracias por registrar tu cuenta en la red IRC &netname&!
 
 --
 Este correo ha sido enviado debido a un comando de &sourceinfo&
-el &date&.  Si no ha solicitado este mensaje, por favor contacte &replyto&
-con una copia del mismo.
+el &date&.  Si no has solicitado este mensaje, por favor contacte a &replyto&
+con una copia completa del mismo.

--- a/email/es/sendpass
+++ b/email/es/sendpass
@@ -6,13 +6,13 @@ Date: &date&
 
 &accountname&,
 
-Alguien ha pedido que la contraseña de su cuenta sea recuperada y
-enviada a su cuenta de correo electrónico. Si usted no solicitó este
-cambio, por favor reportelo inmediatamente, ya que puede ser un intento
-de comprometer su cuenta.
+Alguien ha pedido que la contraseña de tu cuenta sea recuperada y
+enviada a tu cuenta de correo electrónico. Si no solicitaste este
+cambio, por favor repórtelo inmediatamente, ya que puede ser un intento
+de comprometer tu cuenta.
 
 La contraseña de '&accountname&' ha sido cambiada a '&param&'.
 
 --
-Si usted no ha solicitado este mensaje, por favor contacte a &replyto&
-con una copia del mismo.
+Si no has solicitado este mensaje, por favor contacte a &replyto&
+con una copia completa del mismo.

--- a/email/es/setemail
+++ b/email/es/setemail
@@ -11,7 +11,7 @@ e-mail poniendo el siguiente comando en el IRC:
 
    /msg &nicksvs& VERIFY EMAILCHG &accountname& &param&
 
-¡Gracias por actualizar su dirección de e-mail en la red de IRC &netname&!
+¡Gracias por actualizar tu dirección de e-mail en la red de IRC &netname&!
 --
-Si usted no ha solicitado este mensaje, por favor contacte a &replyto&
-con una copia del mismo.
+Si no has solicitado este mensaje, por favor contacte a &replyto&
+con una copia completa del mismo.

--- a/email/es/setpass
+++ b/email/es/setpass
@@ -6,16 +6,16 @@ Date: &date&
 
 &accountname&,
 
-Alguien ha pedido que la contraseña de su cuenta sea recuperada y
-enviada a su cuenta de correo electrónico. Si usted no solicitó este
-cambio, por favor reportelo inmediatamente, ya que puede ser un intento
-de comprometer su cuenta.
+Alguien ha pedido que la contraseña de tu cuenta sea recuperada y
+enviada a tu cuenta de correo electrónico. Si no solicitaste este
+cambio, por favor repórtelo inmediatamente, ya que puede ser un intento
+de comprometer tu cuenta.
 
 Para establecer la nueva contraseña, debes escribir el siguiente comando
-en el IRC, donde <contraseña> es la nueva contraseña que desea tener.
+en el IRC, donde <contraseña> es la nueva contraseña que deseas tener.
 
    /msg &nicksvs& SETPASS &accountname& &param& <contraseña>
 
 --
-Si usted no ha solicitado este mensaje, por favor contacte a &replyto&
-con una copia del mismo.
+Si no has solicitado este mensaje, por favor contacte a &replyto&
+con una copia completa del mismo.


### PR DESCRIPTION
Fixes typos, missing accents, makes formal vs. informal (“usted/tú”, “su/tu”, etc.) usage uniform, makes last line clear that *full* copy of e-mail should be sent (as reflected in the default English files).